### PR TITLE
KK-11519: Add C2B and B2B reversal functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ $K2 = new K2($options);
 - [SendMoneyService](#SendMoneyService) : `$sendMoney = $K2->SendMoneyService();`
 - [PollingService](#pollingservice) : `$polling = $K2->PollingService();`
 - [SmsNotificationService](#smsnotificationservice) : `$sms_notification = $K2->SmsNotificationService();`
+- [ReversalService](#ReversalService): `reversalService = $K2->ReversalService();`
 
 ## Usage
 
@@ -249,13 +250,13 @@ For more information, please read [api-docs#send_money](https://api-docs.kopokop
     - `destinations`: An array of nested associative arrays defining destination details.
     - `currency`: 3-digit ISO format currency code. `REQUIRED`
     - `sourceIdentifier`: The source of funds to transfer, i.e, till number or `null` for available balance.
-    - `metadata`: It is a hash containing a maximum of 5 key value pairs.
+    - `metadata`: It is a hash containing a maximum of 5 key-value pairs.
     - `callbackUrl`: URL that the result will be posted to. `REQUIRED`
     - `accessToken`: Gotten from the [`TokenService`](#tokenservice) response. `REQUIRED`
 
 - `SendMoneyService->getStatus([ statusOptions ])`: `statusOptions`: An associative array containing the following keys:
     - `location`: The request location you get when you send a request. `REQUIRED`
-    - `accessToken`: Gotten from the `TokenService` response. `REQUIRED`
+    - `accessToken`: Gotten from the [`TokenService`](#tokenservice)  response. `REQUIRED`
 
 
 - For more information, please read [api-docs#send_money](https://api-docs.kopokopo.com/#send_money)
@@ -298,6 +299,17 @@ This works the same for all requests that you get a location response.
 
 For more information, please read [api-docs#transaction-sms-notifications](https://api-docs.kopokopo.com/#transaction-sms-notifications)
 
+### `ReversalService`
+- `ReversalService->initiateReversal([ reversalOptions ])`: `reversalOptions`: An associative array containing the following keys:
+  - `transactionReference`: Reference of the transaction to be reversed. `REQUIRED`
+  - `reason`: Reason for the reversal. `REQUIRED`
+  - `metadata`: An associative array with a maximum of 5 key-value pairs.
+  - `callbackUrl`: URL that the result will be posted to. `REQUIRED`
+  - `accessToken`: Gotten from the [`TokenService`](#tokenservice) response. `REQUIRED`
+
+- `ReversalServices->getStatus([ statusOptions ])`: `statusOptions`An associative array containing the following keys:
+  - `location`: The request location you get when you initiate a reversal request. `REQUIRED`
+  - `accessToken`: Gotten from the [`TokenService`](#tokenservice) response. `REQUIRED`
 
 ### Responses and Results
 
@@ -531,6 +543,19 @@ Note: The asynchronous results are processed like webhooks.
   - `linkSelf`
   - `callbackUrl`
 
+- Reversal Result
+  - `id`
+  - `type`
+  - `transactionReference`
+  - `status`
+  - `reason`
+  - `reversalBulkPayment`
+  - `errors`
+  - `metadata`
+  - `createdAt`
+  - `callbackUrl`
+  - `linkSelf`
+
 #### Status Payloads
 
 - Webhook Subscription Status
@@ -621,6 +646,9 @@ Note: The asynchronous results are processed like webhooks.
 
 - Transaction SMS Notification Status
   - This payload is the same as the `Transaction SMS Notification` result payload
+
+- Reversal Status
+  - This payload is similar to `Reversal Result` payload
 
 #### Error responses
 

--- a/README.md
+++ b/README.md
@@ -250,11 +250,12 @@ For more information, please read [api-docs#send_money](https://api-docs.kopokop
     - `currency`: 3-digit ISO format currency code. `REQUIRED`
     - `sourceIdentifier`: The source of funds to transfer, i.e, till number or `null` for available balance.
     - `metadata`: It is a hash containing a maximum of 5 key value pairs.
+    - `callbackUrl`: URL that the result will be posted to. `REQUIRED`
     - `accessToken`: Gotten from the [`TokenService`](#tokenservice) response. `REQUIRED`
 
-- `SendMoneyService->getStatus([ location ])`:
+- `SendMoneyService->getStatus([ statusOptions ])`: `statusOptions`: An associative array containing the following keys:
     - `location`: The request location you get when you send a request. `REQUIRED`
-    - `accessToken`: Gotten from the TokenService response. `REQUIRED`
+    - `accessToken`: Gotten from the `TokenService` response. `REQUIRED`
 
 
 - For more information, please read [api-docs#send_money](https://api-docs.kopokopo.com/#send_money)

--- a/example/index.php
+++ b/example/index.php
@@ -97,6 +97,10 @@ $router->map('GET', '/smsnotification', function () {
     require __DIR__.'/views/smsnotification.php';
 });
 
+$router->map("GET", "/reversals", function () {
+    require __DIR__."/views/reversals.php";
+});
+
 $router->map('GET', '/token', function () {
     global $K2;
 
@@ -430,6 +434,25 @@ $router->map('GET', '/webhook/resource', function () {
     } else {
         echo json_encode(['message' => 'No response yet.']);
     }
+});
+
+$router->map("POST", "/reversals", function () {
+    global $K2;
+    $tokenService = $K2->TokenService();
+    $response = $tokenService->getToken();
+    $accessToken = $response["data"]["accessToken"];
+    $reversalService = $K2->ReversalService();
+
+    $options = [
+        "transactionReference" => $_POST["transactionReference"],
+        "reason" => $_POST["reason"],
+        "callbackUrl" => $_POST["callbackUrl"],
+        "accessToken" => $accessToken,
+    ];
+
+    $response = $reversalService->initiateReversal($options);
+
+    echo "<pre>".json_encode($response, JSON_ENCODING_FLAGS)."</pre>";
 });
 
 $match = $router->match();

--- a/example/views/partials/nav.php
+++ b/example/views/partials/nav.php
@@ -42,6 +42,15 @@
                 </div>
             </li>
             <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropDownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Reversals
+                </a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropDownMenuLink">
+                    <a class="dropdown-item" href="/reversals">Reverse Transaction</a>
+                    <a class="dropdown-item" href="/status">Query Reversal Status</a>
+                </div>
+            </li>
+            <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Polling
                 </a>

--- a/example/views/reversals.php
+++ b/example/views/reversals.php
@@ -1,0 +1,37 @@
+<?php
+    include "layout.php";
+?>
+<div class="container">
+    <form id="reversals" action="/reversals" method="post">
+        <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="transactionReference">Transaction Reference</label>
+            <div class="col-sm-7">
+                <input class="form-control" name="transactionReference" type="text" placeholder="Enter transaction reference" required/>
+                <div class="small form-text text-muted">Enter the transaction reference</div>
+            </div>
+        </div>
+
+        <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="reason">Reversal Reason</label>
+            <div class="col-sm-7">
+                <input class="form-control" name="reason" type="text" placeholder="Enter reason for reversal" required/>
+                <div class="small form-text text-muted">Enter the reason for reversal</div>
+            </div>
+        </div>
+
+        <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="callbackUrl">Callback URL</label>
+            <div class="col-sm-7">
+                <input class="form-control" name="callbackUrl" type="text" placeholder="Enter callback url" required/>
+                <div class="small form-text text-muted">Enter the callback url</div>
+            </div>
+        </div>
+
+        <br/>
+        <div class="form-group row">
+            <div class="col-sm-7">
+                <button class="btn btn-success" type="submit">Reverse Transaction</button>
+            </div>
+        </div>
+    </form>
+</div>

--- a/src/K2.php
+++ b/src/K2.php
@@ -92,4 +92,9 @@ class K2
 
         return $smsNotify;
     }
+
+    public function ReversalService(): ReversalService
+    {
+        return new ReversalService($this->client, $this->options);
+    }
 }

--- a/src/ReversalService.php
+++ b/src/ReversalService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kopokopo\SDK;
+
+use Kopokopo\SDK\Requests\ReversalRequest;
+use Kopokopo\SDK\Data\FailedResponseData;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\BadResponseException;
+use Exception;
+
+class ReversalService extends Service
+{
+    public function initiateReversal($options): array
+    {
+        $reversalRequest = new ReversalRequest($options);
+
+        try {
+            $response = $this->client->post(
+                "reversals",
+                [
+                    "body" => json_encode($reversalRequest->getReversalRequestBody()),
+                    "headers" => $reversalRequest->getHeaders(),
+                ]
+            );
+
+            return $this->postSuccess($response);
+        } catch (BadResponseException $e) {
+            $dataHandler = new FailedResponseData();
+            return $this->error($dataHandler->setErrorData($e));
+        } catch (GuzzleException | Exception $e) {
+            return $this->error($e->getMessage());
+        }
+    }
+}

--- a/src/data/ResultDataHandler.php
+++ b/src/data/ResultDataHandler.php
@@ -24,6 +24,8 @@ class ResultDataHandler
                 return PollingData::setData($data);
             case "transaction_sms_notification":
                 return TransactionSmsNotificationData::setData($data);
+            case "reversals":
+                return ReversalData::setData($data);
         }
     }
 }

--- a/src/data/ReversalData.php
+++ b/src/data/ReversalData.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kopokopo\SDK\Data;
+
+use Kopokopo\SDK\Helpers\K2Utils;
+
+class ReversalData
+{
+    public static function setData($result): array
+    {
+        return  [
+            "id" => $result["id"],
+            "type" => $result["type"],
+            "transactionReference" => $result["attributes"]["transaction_reference"],
+            "status" => $result["attributes"]["status"],
+            "reason" => $result["attributes"]["reason"],
+            "reversalBulkPayment" => K2Utils::deepCamelizeKeys($result["attributes"]["reversal_bulk_payment"]),
+            "errors" => $result["attributes"]["errors"],
+            "metadata" => $result["attributes"]["metadata"],
+            "createdAt" => $result["attributes"]["created_at"],
+            "callbackUrl" => $result["attributes"]["_links"]["callback_url"],
+            "linkSelf" => $result["attributes"]["_links"]["self"],
+        ];
+    }
+}

--- a/src/requests/ReversalRequest.php
+++ b/src/requests/ReversalRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Kopokopo\SDK\Requests;
+
+class ReversalRequest extends BaseRequest
+{
+    public function getReversalRequestBody(): array {
+        return [
+            "transaction_reference" => $this->getTransactionReference(),
+            "reason" => $this->getReversalReason(),
+            "metadata" => $this->getMetadata(),
+            "_links" => [
+                "callback_url" => $this->getCallbackUrl(),
+            ],
+        ];
+    }
+
+    private function getTransactionReference(): string
+    {
+        return $this->getRequestData("transactionReference");
+    }
+
+    private function getReversalReason(): string
+    {
+        return $this->getRequestData("reason");
+    }
+
+    private function getMetadata(): ?array
+    {
+        if (!isset($this->data["metadata"])) return null;
+
+        return $this->getRequestData("metadata");
+    }
+
+    private function getCallbackUrl(): string
+    {
+        return $this->getRequestData("callbackUrl");
+    }
+}

--- a/tests/Mocks/reversals/reversalError.json
+++ b/tests/Mocks/reversals/reversalError.json
@@ -1,0 +1,4 @@
+{
+  "error_code": 400,
+  "error_message": "Transaction reference invalid"
+}

--- a/tests/Mocks/reversals/reversalHeaders.json
+++ b/tests/Mocks/reversals/reversalHeaders.json
@@ -1,0 +1,4 @@
+{
+  "location": "https://sandbox.kopokopo.com/api/v2/reversals/b42e022a-594e-47c3-b717-a259a5797312",
+  "Content-Type": "application/json"
+}

--- a/tests/Mocks/reversals/reversalStatus.json
+++ b/tests/Mocks/reversals/reversalStatus.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "id": "b42e022a-594e-47c3-b717-a259a5797312",
+    "type": "reversals",
+    "attributes": {
+      "status": "Processed",
+      "created_at": "2026-01-19T14:09:38.131+03:00",
+      "transaction_reference": "JAN1622026",
+      "reason": "Double payment",
+      "reversal_bulk_payment": {
+        "amount": "6182.0",
+        "status": "Transferred",
+        "origination_time": "2026-01-19T13:38:11.611+03:00",
+        "transaction_reference": "REVJAN7062026"
+      },
+      "errors": null,
+      "metadata": {
+        "name": "Some metadata"
+      },
+      "_links": {
+        "callback_url": "https://webhook.site/b5da6de6-ba87-4120-aec0-d3e52a52cb26",
+        "self": "https://sandbox.kopokopo.com/api/v2/reversals/b42e022a-594e-47c3-b717-a259a5797312"
+      }
+    }
+  }
+}

--- a/tests/ReversalServiceTest.php
+++ b/tests/ReversalServiceTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Kopokopo\SDK\Tests;
+require "vendor/autoload.php";
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Kopokopo\SDK\Helpers\K2Utils;
+use Kopokopo\SDK\ReversalService;
+use PHPUnit\Framework\TestCase;
+
+class ReversalServiceTest extends TestCase
+{
+    private ReversalService $reversalService;
+
+    private function getK2Options(): array {
+        return [
+            "clientId" => "your_client_id",
+            "clientSecret" => "your_client_secret",
+            "apiKey" => "your_api_key",
+            "baseUrl" => "http://localhost:8000"
+        ];
+    }
+
+    function setup(): void
+    {
+        $k2Options = $this->getK2Options();
+        $reversalHeaders = file_get_contents((__DIR__."/Mocks/reversals/reversalHeaders.json"));
+        $reversalMock = new MockHandler([ new Response(200, json_decode($reversalHeaders, true))]);
+        $reversalHandler = HandlerStack::create($reversalMock);
+        $reversalClient = new Client(["handler" => $reversalHandler]);
+        $this->reversalService = new ReversalService($reversalClient, $k2Options);
+    }
+
+    private function setUpGetReversalStatus(): void
+    {
+        $k2Options = $this->getK2Options();
+        $reversalStatus = file_get_contents((__DIR__."/Mocks/reversals/reversalStatus.json"));
+        $reversalMock = new MockHandler([ new Response(200, [], $reversalStatus)]);
+        $reversalHandler = HandlerStack::create($reversalMock);
+        $reversalClient = new Client(["handler" => $reversalHandler]);
+        $this->reversalService = new ReversalService($reversalClient, $k2Options);
+    }
+
+    // Initiate reversal
+    public function testInitiateReversalSucceeds(): void
+    {
+        $response = $this->reversalService->initiateReversal([
+            "transactionReference" => "J82K922T92",
+            "reason" => "Double payment",
+            "metadata" => [
+                "notes" => "John Doe reached out due to double payment.",
+                "zendeskTicket" => "ZND2393334",
+            ],
+            "callbackUrl" => "http://localhost:8000/reversal_results",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("success", $response["status"]);
+        $this->assertEquals("https://sandbox.kopokopo.com/api/v2/reversals/b42e022a-594e-47c3-b717-a259a5797312", $response["location"]);
+    }
+
+    public function testInitiateReversalWithoutMetadataSucceeds(): void
+    {
+        $response = $this->reversalService->initiateReversal([
+            "transactionReference" => "J82K922T92",
+            "reason" => "Double payment",
+            "callbackUrl" => "http://localhost:8000/reversal_results",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("success", $response["status"]);
+        $this->assertEquals("https://sandbox.kopokopo.com/api/v2/reversals/b42e022a-594e-47c3-b717-a259a5797312", $response["location"]);
+    }
+
+    public function testInitiateReversalWithoutTransactionReferenceFails(): void
+    {
+        $response = $this->reversalService->initiateReversal([
+            "reason" => "Double payment",
+            "metadata" => [
+                "notes" => "John Doe reached out due to double payment.",
+                "zendeskTicket" => "ZND2393334",
+            ],
+            "callbackUrl" => "http://localhost:8000/reversal_results",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the transactionReference", $response["data"]);
+    }
+
+    public function testInitiateReversalWithoutReasonFails(): void
+    {
+        $response = $this->reversalService->initiateReversal([
+            "transactionReference" => "J82K922T92",
+            "metadata" => [
+                "notes" => "John Doe reached out due to double payment.",
+                "zendeskTicket" => "ZND2393334",
+            ],
+            "callbackUrl" => "http://localhost:8000/reversal_results",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the reason", $response["data"]);
+    }
+
+    public function testInitiateReversalWithoutCallbackUrlFails(): void
+    {
+        $response = $this->reversalService->initiateReversal([
+            "transactionReference" => "J82K922T92",
+            "reason" => "Double payment",
+            "metadata" => [
+                "notes" => "John Doe reached out due to double payment.",
+                "zendeskTicket" => "ZND2393334",
+            ],
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the callbackUrl", $response["data"]);
+    }
+
+    public function testInitiateReversalWithoutAccessTokenFails(): void
+    {
+        $response = $this->reversalService->initiateReversal([
+            "transactionReference" => "J82K922T92",
+            "reason" => "Double payment",
+            "metadata" => [
+                "notes" => "John Doe reached out due to double payment.",
+                "zendeskTicket" => "ZND2393334",
+            ],
+            "callbackUrl" => "http://localhost:8000/reversal_results",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the accessToken", $response["data"]);
+    }
+
+    public function testInitiateReversalHandlesRequestExceptionsGracefully(): void {
+        $k2Options = $this->getK2Options();
+        $reversalError = file_get_contents(__DIR__."/Mocks/reversals/reversalError.json");
+        $reversalMock = new MockHandler([new Response(400, [], $reversalError),]);
+        $reversalHandler = HandlerStack::create($reversalMock);
+        $reversalClient = new Client(["handler" => $reversalHandler]);
+        $this->reversalService = new ReversalService($reversalClient, $k2Options);
+        $response = $this->reversalService->initiateReversal([
+            "transactionReference" => "Invalid transaction reference",
+            "reason" => "Double payment",
+            "metadata" => [
+                "notes" => "John Doe reached out due to double payment.",
+                "zendeskTicket" => "ZND2393334",
+            ],
+            "callbackUrl" => "http://localhost:8000/reversal_results",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("400", $response["data"]["errorCode"]);
+        $this->assertEquals("Transaction reference invalid", $response["data"]["errorMessage"]);
+    }
+
+    // Query reversal status
+    public function testGetReversalRequestStatusSucceeds(): void
+    {
+        $this->setUpGetReversalStatus();
+        $result = json_decode(file_get_contents(__DIR__."/Mocks/reversals/reversalStatus.json"), true)["data"];
+        $response = $this->reversalService->getStatus([
+            "location" => "https://sandbox.kopokopo.com/api/v2/reversals/b42e022a-594e-47c3-b717-a259a5797312",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $formattedResult = [
+            "id" => $result["id"],
+            "type" => $result["type"],
+            "transactionReference" => $result["attributes"]["transaction_reference"],
+            "status" => $result["attributes"]["status"],
+            "reason" => $result["attributes"]["reason"],
+            "reversalBulkPayment" => K2Utils::deepCamelizeKeys($result["attributes"]["reversal_bulk_payment"]),
+            "errors" => $result["attributes"]["errors"],
+            "metadata" => $result["attributes"]["metadata"],
+            "createdAt" => $result["attributes"]["created_at"],
+            "callbackUrl" => $result["attributes"]["_links"]["callback_url"],
+            "linkSelf" => $result["attributes"]["_links"]["self"],
+        ];
+
+        $this->assertEquals("success", $response["status"]);
+        $this->assertEquals($formattedResult, $response["data"]);
+    }
+
+    public function testGetReversalRequestStatusWithoutLocationFails(): void
+    {
+        $this->setUpGetReversalStatus();
+        $response = $this->reversalService->getStatus([
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the location", $response["data"]);
+    }
+
+    public function testGetReversalRequestStatusWithoutAccessTokenFails(): void
+    {
+        $this->setUpGetReversalStatus();
+        $response = $this->reversalService->getStatus([
+            "location" => "https://sandbox.kopokopo.com/api/v2/reversals/b42e022a-594e-47c3-b717-a259a5797312",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the accessToken", $response["data"]);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to initiate C2B and B2B reversals. This has also been added to the example app.

**Reversals on the example app**
[Screencast from 2026-01-19 21-16-27.webm](https://github.com/user-attachments/assets/e407b2b9-2053-4e48-a379-e577fbe07641)


**Response data for querying the status of an unprocessed reversal request**
<img width="919" height="392" alt="image" src="https://github.com/user-attachments/assets/86bff76d-16c9-48e1-a79b-3f05b67d88a1" />

**Response data for querying the status of a transferred reversal request**
<img width="919" height="392" alt="image" src="https://github.com/user-attachments/assets/1aba5ea1-0f76-40fa-960e-8464a379b9f3" />

**Response data for querying the status of a cancelled reversal request**
<img width="919" height="392" alt="image" src="https://github.com/user-attachments/assets/18ea76ef-1db4-416e-8d07-66a5fe831e8e" />


**Reversal service test cases**
<img width="591" height="354" alt="Screenshot from 2026-01-20 10-52-08" src="https://github.com/user-attachments/assets/25767c51-fa90-4edf-b9cd-c1c8a9097867" />

**All tests cases**
<img width="852" height="204" alt="image" src="https://github.com/user-attachments/assets/3e372b5b-49be-4640-83f0-526909831f13" />
