### PR TITLE
KK-11499: Add functionality to create, cancel and view payment links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ $K2 = new K2($options);
 - [PollingService](#pollingservice) : `$polling = $K2->PollingService();`
 - [SmsNotificationService](#smsnotificationservice) : `$sms_notification = $K2->SmsNotificationService();`
 - [ReversalService](#ReversalService): `reversalService = $K2->ReversalService();`
+- [PaymentLinkService](#PaymentLinkService): `paymentLinkService = $K2->PaymentLinkService();`
 
 ## Usage
 
@@ -311,6 +312,26 @@ For more information, please read [api-docs#transaction-sms-notifications](https
   - `location`: The request location you get when you initiate a reversal request. `REQUIRED`
   - `accessToken`: Gotten from the [`TokenService`](#tokenservice) response. `REQUIRED`
 
+
+### `PaymentLinkService`
+- `PaymentLinkService->createPaymentLink([ paymentLinkOptions ]):` `paymentLinkOptions`: An associative array containing the following keys:
+  - `tillNumber`: Till number for the **M-PESA** or **Online Payments Account** that will receive the payment. `REQUIRED`
+  - `currency`: 3-digit ISO format currency code. `REQUIRED`
+  - `amount`: The amount the customer will pay. `REQUIRED`
+  - `paymentReference`: The merchant internal reference for the payment.
+  - `note`: Note for the customer as they make the payment.
+  - `metadata`: An associative array with a maximum of 5 key pairs.
+  - `callbackUrl`: URL that the payment link result will be posted to once a customer makes a payment. `REQUIRED`
+  - `accessToken`: Gotten from the `TokenService` response. `REQUIRED`
+
+- `PaymentLinkService->cancelPaymentLink([ cancellationOptions ])`: `cancellationOptions`: An associative array containing the following keys:
+  - `location`: The request location you get when you send a payment link request. `REQUIRED`
+  - `accessToken`: Gotten from the `TokenService` response. `REQUIRED`
+
+- `PaymentLinkService->getStatus([ statusOptions ])`: `statusOptions`: An associative array containing the following keys:
+    - `location`: The request location you get when you send a payment link request. `REQUIRED`
+    - `accessToken`: Gotten from the `TokenService` response. `REQUIRED`
+
 ### Responses and Results
 
 - All the post requests are asynchronous apart from `TokenService`. This means that the result will be posted to your custom callback url when the request is complete. The immediate response of the post requests contain the `location` url of the request you have sent which you can use to query the status.
@@ -556,6 +577,23 @@ Note: The asynchronous results are processed like webhooks.
   - `callbackUrl`
   - `linkSelf`
 
+- Payment Link Result
+  - `id`
+  - `type`
+  - `status`
+  - `currency`
+  - `amount`
+  - `tillName`
+  - `tillNumber`
+  - `paymentReference`
+  - `note`
+  - `createdAt`
+  - `paymentLink`
+  - `errors`
+  - `metadata`
+  - `callbackUrl`
+  - `linkSelf`
+
 #### Status Payloads
 
 - Webhook Subscription Status
@@ -626,7 +664,7 @@ Note: The asynchronous results are processed like webhooks.
 - Stk Push Status
 
   - Successful request
-    - This payload is simialr to the successful result
+    - This payload is similar to the successful result
   - Failed request
     - This payload is similar to failed result
   - Pending request
@@ -649,6 +687,9 @@ Note: The asynchronous results are processed like webhooks.
 
 - Reversal Status
   - This payload is similar to `Reversal Result` payload
+
+- Payment Link Status
+  - This payload is similar to `Payment Link Result` payload
 
 #### Error responses
 

--- a/example/index.php
+++ b/example/index.php
@@ -101,6 +101,14 @@ $router->map("GET", "/reversals", function () {
     require __DIR__."/views/reversals.php";
 });
 
+$router->map("GET", "/payment_links", function () {
+    require __DIR__."/views/payment_links.php";
+});
+
+$router->map("GET", "/cancel_payment_links", function () {
+    require __DIR__."/views/cancel_payment_links.php";
+});
+
 $router->map('GET', '/token', function () {
     global $K2;
 
@@ -451,6 +459,45 @@ $router->map("POST", "/reversals", function () {
     ];
 
     $response = $reversalService->initiateReversal($options);
+
+    echo "<pre>".json_encode($response, JSON_ENCODING_FLAGS)."</pre>";
+});
+
+$router->map("POST", "/payment_links", function () {
+    global $K2;
+    $tokenService = $K2->TokenService();
+    $response = $tokenService->getToken();
+    $accessToken = $response["data"]["accessToken"];
+    $paymentLinkService = $K2->PaymentLinkService();
+
+    $options = [
+        "tillNumber" => $_POST["tillNumber"],
+        "currency" => "KES",
+        "amount" => $_POST["amount"],
+        "paymentReference" => $_POST["paymentReference"] ?? null,
+        "note" => $_POST["note"] ?? null,
+        "callbackUrl" => $_POST["callbackUrl"],
+        "accessToken" => $accessToken,
+    ];
+
+    $response = $paymentLinkService->createPaymentLink($options);
+
+    echo "<pre>".json_encode($response, JSON_ENCODING_FLAGS)."</pre>";
+});
+
+$router->map("POST", "/cancel_payment_links", function () {
+    global $K2;
+    $tokenService = $K2->TokenService();
+    $response = $tokenService->getToken();
+    $accessToken = $response["data"]["accessToken"];
+    $paymentLinkService = $K2->PaymentLinkService();
+
+    $options = [
+        "location" => $_POST["location"],
+        "accessToken" => $accessToken,
+    ];
+
+    $response = $paymentLinkService->cancelPaymentLink($options);
 
     echo "<pre>".json_encode($response, JSON_ENCODING_FLAGS)."</pre>";
 });

--- a/example/views/cancel_payment_links.php
+++ b/example/views/cancel_payment_links.php
@@ -1,0 +1,21 @@
+<?php
+    include "layout.php";
+?>
+<div class="container">
+    <form id="cancelPaymentLink" action="/cancel_payment_links" method="post">
+        <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="location">Location URL</label>
+            <div class="col-sm-7">
+                <input class="form-control" name="location" type="text" placeholder="Enter location url" required/>
+                <div class="small form-text text-muted">Enter the location url</div>
+            </div>
+        </div>
+
+        <br/>
+        <div class="form-group row">
+            <div class="col-sm-7">
+                <button class="btn btn-success" type="submit">Cancel Payment Link</button>
+            </div>
+        </div>
+    </form>
+</div>

--- a/example/views/partials/nav.php
+++ b/example/views/partials/nav.php
@@ -51,6 +51,16 @@
                 </div>
             </li>
             <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropDownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Payment Links
+                </a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropDownMenuLink">
+                    <a class="dropdown-item" href="/payment_links">Create Payment Link</a>
+                    <a class="dropdown-item" href="/cancel_payment_links">Cancel Payment Link</a>
+                    <a class="dropdown-item" href="/status">Query Payment Link Status</a>
+                </div>
+            </li>
+            <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Polling
                 </a>

--- a/example/views/payment_links.php
+++ b/example/views/payment_links.php
@@ -1,0 +1,53 @@
+<?php
+    include "layout.php";
+?>
+<div class="container">
+    <form id="paymentLink" action="/payment_links" method="post">
+        <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="tillNumber">Till Number</label>
+            <div class="col-sm-7">
+                <input class="form-control" name="tillNumber" type="text" placeholder="Enter till number" required/>
+                <div class="small form-text text-muted">Enter the till number</div>
+            </div>
+        </div>
+
+        <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="amount">Amount</label>
+            <div class="col-sm-7">
+                <input class="form-control" name="amount" type="text" placeholder="Enter the amount" required/>
+                <div class="small form-text text-muted">Enter the amount</div>
+            </div>
+        </div>
+
+        <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="paymentReference">Payment Reference</label>
+            <div class="col-sm-7">
+                <input class="form-control" name="paymentReference" type="text" placeholder="Merchant payment reference"/>
+                <div class="small form-text text-muted">Enter your payment reference</div>
+            </div>
+        </div>
+
+        <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="note">Note</label>
+            <div class="col-sm-7">
+                <input class="form-control" name="note" type="text" placeholder="Customer note"/>
+                <div class="small form-text text-muted">Enter note for your customer</div>
+            </div>
+        </div>
+
+        <div class="form-group row">
+            <label class="col-sm-2 col-form-label" for="callbackUrl">Callback URL</label>
+            <div class="col-sm-7">
+                <input class="form-control" name="callbackUrl" type="text" placeholder="Enter callback url" required/>
+                <div class="small form-text text-muted">Enter the callback url</div>
+            </div>
+        </div>
+
+        <br/>
+        <div class="form-group row">
+            <div class="col-sm-7">
+                <button class="btn btn-success" type="submit">Create Payment Link</button>
+            </div>
+        </div>
+    </form>
+</div>

--- a/src/K2.php
+++ b/src/K2.php
@@ -97,4 +97,9 @@ class K2
     {
         return new ReversalService($this->client, $this->options);
     }
+
+    public function PaymentLinkService(): PaymentLinkService
+    {
+        return new PaymentLinkService($this->client, $this->options);
+    }
 }

--- a/src/PaymentLinkService.php
+++ b/src/PaymentLinkService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Kopokopo\SDK;
+
+use Kopokopo\SDK\Requests\PaymentLinkRequest;
+use Kopokopo\SDK\Requests\PaymentLinkCancellationRequest;
+use Kopokopo\SDK\Data\FailedResponseData;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\BadResponseException;
+use \Exception;
+
+class PaymentLinkService extends Service
+{
+    public function createPaymentLink(array $options): array {
+        $paymentLinkRequest = new PaymentLinkRequest($options);
+        try {
+            $response = $this->client->post(
+                "payment_links",
+                [
+                    "body" => json_encode($paymentLinkRequest->getPaymentLinkRequestBody()),
+                    "headers" => $paymentLinkRequest->getHeaders()
+                ]
+            );
+
+            return $this->postSuccess($response);
+        } catch (BadResponseException $e) {
+           $dataHandler = new FailedResponseData();
+           return $this->error($dataHandler->setErrorData($e));
+        } catch (GuzzleException | Exception $e) {
+            return $this->error($e->getMessage());
+        }
+    }
+
+    public function cancelPaymentLink(array $options): array {
+        $paymentLinkCancellationRequest = new PaymentLinkCancellationRequest($options);
+        try {
+            $response = $this->client->post(
+                $paymentLinkCancellationRequest->getCancellationURL(),
+                [
+                    "headers" => $paymentLinkCancellationRequest->getHeaders()
+                ]
+            );
+
+            return [
+                "status" => "success",
+                "message" => json_decode($response->getBody()->getContents(), true)["message"],
+            ];
+        } catch (BadResponseException $e) {
+            $dataHandler = new FailedResponseData();
+            return $this->error($dataHandler->setErrorData($e));
+        } catch (GuzzleException | Exception $e) {
+            return $this->error($e->getMessage());
+        }
+    }
+}

--- a/src/data/FailedResponseData.php
+++ b/src/data/FailedResponseData.php
@@ -12,7 +12,7 @@ class FailedResponseData
 
             if(empty($response->getBody()) || empty(json_decode($response->getBody(), true)['error_message'])) {
                 $this->data['errorCode'] = $response->getStatusCode();
-                $this->data['errorMessage'] = empty($response->getBody()) ? $response->getReasonPhrase() : $response->getBody();
+                $this->data['errorMessage'] = empty(json_decode($response->getBody())) ? $response->getReasonPhrase() : $response->getBody();
 
             } else {
                 $errorPayload = json_decode($e->getResponse()->getBody(), true);

--- a/src/data/PaymentLinkData.php
+++ b/src/data/PaymentLinkData.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Kopokopo\SDK\Data;
+
+use Kopokopo\SDK\Helpers\K2Utils;
+
+class PaymentLinkData
+{
+    public static function setData(array $result): array
+    {
+        return [
+            "id" => $result["id"],
+            "type" => $result["type"],
+            "status" => $result["attributes"]["status"],
+            "currency" => $result["attributes"]["currency"],
+            "amount" => $result["attributes"]["amount"],
+            "tillName" => $result["attributes"]["till_name"],
+            "tillNumber" => $result["attributes"]["till_number"],
+            "paymentReference" => $result["attributes"]["payment_reference"],
+            "note" => $result["attributes"]["note"],
+            "createdAt" => $result["attributes"]["created_at"],
+            "paymentLink" => K2Utils::deepCamelizeKeys($result["attributes"]["payment_link"]),
+            "errors" => $result["attributes"]["errors"],
+            "metadata" => $result["attributes"]["metadata"],
+            "callbackUrl" => $result["attributes"]["_links"]["callback_url"],
+            "linkSelf" => $result["attributes"]["_links"]["self"],
+        ];
+    }
+}

--- a/src/data/ResultDataHandler.php
+++ b/src/data/ResultDataHandler.php
@@ -26,6 +26,8 @@ class ResultDataHandler
                 return TransactionSmsNotificationData::setData($data);
             case "reversals":
                 return ReversalData::setData($data);
+            case "payment_link":
+                return PaymentLinkData::setData($data);
         }
     }
 }

--- a/src/requests/PaymentLinkCancellationRequest.php
+++ b/src/requests/PaymentLinkCancellationRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Kopokopo\SDK\Requests;
+
+class PaymentLinkCancellationRequest extends BaseRequest
+{
+    public function getCancellationURL(): string {
+        return $this->getLocation() ."/cancel";
+    }
+
+    private function getLocation() {
+        return $this->getRequestData("location");
+    }
+}

--- a/src/requests/PaymentLinkRequest.php
+++ b/src/requests/PaymentLinkRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Kopokopo\SDK\Requests;
+
+class PaymentLinkRequest extends BaseRequest
+{
+    public function getPaymentLinkRequestBody(): array
+    {
+        return [
+            "till_number" => $this->getTillNumber(),
+            "currency" => $this->getCurrency(),
+            "amount" => $this->getAmount(),
+            "payment_reference" => $this->getPaymentReference(),
+            "note" => $this->getNote(),
+            "metadata" => $this->getMetadata(),
+            "callback_url" => $this->getCallbackUrl(),
+        ];
+    }
+
+    private function getTillNumber(): string
+    {
+        return $this->getRequestData("tillNumber");
+    }
+
+    private function getCurrency(): string
+    {
+        return $this->getRequestData("currency");
+    }
+
+    private function getAmount(): float
+    {
+        return $this->getRequestData("amount");
+    }
+
+    private function getPaymentReference(): ?string
+    {
+        if (!isset($this->data["paymentReference"])) return null;
+
+        return $this->getRequestData("paymentReference");
+    }
+
+    private function getNote(): ?string
+    {
+        if (!isset($this->data["note"])) return null;
+
+        return $this->getRequestData("note");
+    }
+
+    private function getMetadata(): ?array
+    {
+        if (!isset($this->data["metadata"])) return null;
+
+        return $this->getRequestData("metadata");
+    }
+
+    private function getCallbackUrl(): string
+    {
+        return $this->getRequestData("callbackUrl");
+    }
+}

--- a/tests/Mocks/paymentLinks/paymentLinkCancellation.json
+++ b/tests/Mocks/paymentLinks/paymentLinkCancellation.json
@@ -1,0 +1,3 @@
+{
+  "message": "Payment link cancelled."
+}

--- a/tests/Mocks/paymentLinks/paymentLinkError.json
+++ b/tests/Mocks/paymentLinks/paymentLinkError.json
@@ -1,0 +1,4 @@
+{
+  "error_code": 400,
+  "error_message": "Till number is invalid"
+}

--- a/tests/Mocks/paymentLinks/paymentLinkHeaders.json
+++ b/tests/Mocks/paymentLinks/paymentLinkHeaders.json
@@ -1,0 +1,4 @@
+{
+  "location": "https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312",
+  "Content-Type": "application/json"
+}

--- a/tests/Mocks/paymentLinks/paymentLinkStatus.json
+++ b/tests/Mocks/paymentLinks/paymentLinkStatus.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "id": "d5963294-22bf-46f6-a13c-b6a9951b4312",
+    "type": "payment_link",
+    "attributes": {
+      "status": "Processed",
+      "created_at": "2026-01-20T19:58:30.460+03:00",
+      "till_name": "The Continental Ltd - Till 1",
+      "till_number": "4321",
+      "payment_reference": "INV29390943",
+      "currency": "KES",
+      "amount": 2000,
+      "note": "Note to customer",
+      "payment_link": {
+        "payment_link_status": "active",
+        "expires_at": "2026-01-27T19:58:30.483+03:00",
+        "initiator_name": "John Doe",
+        "link": "https://sandbox.kopokopo.com/links/04a976cc-b27d-4f4f-afdc-7b7e9bbefe00"
+      },
+      "errors": null,
+      "metadata": {
+        "deliveryAddress": "1234, ABC Street",
+        "promotionDetails": "End of Year Sale"
+      },
+      "_links": {
+        "callback_url": "https://webhook.site/b5da6de6-ba87-4120-aec0-d3e52a52cb26",
+        "self": "https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312"
+      }
+    }
+  }
+}

--- a/tests/PaymentLinkServiceTest.php
+++ b/tests/PaymentLinkServiceTest.php
@@ -1,0 +1,359 @@
+<?php
+
+namespace Kopokopo\SDK\Tests;
+require "vendor/autoload.php";
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Kopokopo\SDK\Helpers\K2Utils;
+use Kopokopo\SDK\PaymentLinkService;
+use PHPUnit\Framework\TestCase;
+
+class PaymentLinkServiceTest extends TestCase
+{
+    private PaymentLinkService $paymentLinkService;
+
+    private function getK2Options(): array {
+        return [
+            "clientId" => "your_client_id",
+            "clientSecret" => "your_client_secret",
+            "apiKey" => "your_api_key",
+            "baseUrl" => "http://localhost:8000"
+        ];
+    }
+
+    function setup(): void
+    {
+        $k2Options = $this->getK2Options();
+
+        $paymentLinkRequestHeaders = file_get_contents(__DIR__."/Mocks/paymentLinks/paymentLinkHeaders.json");
+        $paymentLinkMock = new MockHandler([new Response(200, json_decode($paymentLinkRequestHeaders, true)),]);
+        $paymentLinkHandler = HandlerStack::create($paymentLinkMock);
+        $paymentLinkClient = new Client(["handler" => $paymentLinkHandler]);
+        $this->paymentLinkService = new PaymentLinkService($paymentLinkClient, $k2Options);
+    }
+
+    private function setUpGetPaymentLinkStatus(): void {
+        $k2Options = $this->getK2Options();
+
+        $paymentLinkStatusPayload = file_get_contents(__DIR__."/Mocks/paymentLinks/paymentLinkStatus.json");
+        $paymentLinkMock = new MockHandler([new Response(200, [], $paymentLinkStatusPayload)]);
+        $paymentLinkHandler = HandlerStack::create($paymentLinkMock);
+        $paymentLinkClient = new Client(["handler" => $paymentLinkHandler]);
+        $this->paymentLinkService = new PaymentLinkService($paymentLinkClient, $k2Options);
+    }
+
+    private function setUpCancelPaymentLink(): void {
+        $k2Options = $this->getK2Options();
+
+        $paymentLinkCancellationResponse = file_get_contents(__DIR__."/Mocks/paymentLinks/paymentLinkCancellation.json");
+        $paymentLinkCancellationMock = new MockHandler([new Response(200, [], $paymentLinkCancellationResponse)]);
+        $paymentLinkCancellationHandler = HandlerStack::create($paymentLinkCancellationMock);
+        $paymentLinkClient = new Client(["handler" => $paymentLinkCancellationHandler]);
+        $this->paymentLinkService = new PaymentLinkService($paymentLinkClient, $k2Options);
+    }
+
+    private function setUpPaymentLinkRequestError(): void {
+        $k2Options = $this->getK2Options();
+        $paymentLinkError = file_get_contents(__DIR__."/Mocks/paymentLinks/paymentLinkError.json");
+        $paymentLinkMock = new MockHandler([new Response(400, [], $paymentLinkError),]);
+        $paymentLinkHandler = HandlerStack::create($paymentLinkMock);
+        $paymentLinkClient = new Client(["handler" => $paymentLinkHandler]);
+        $this->paymentLinkService = new PaymentLinkService($paymentLinkClient, $k2Options);
+    }
+
+    // Create payment link
+    public function testCreatePaymentLinkSucceeds()
+    {
+        $response = $this->paymentLinkService->createPaymentLink([
+            "tillNumber" => "4321",
+            "currency" => "KES",
+            "amount" => 2000.00,
+            "paymentReference" => "INV29390943",
+            "note" => "Note to customer",
+            "metadata" => [
+                "promotionDetails" => "End of Year Sale",
+                "deliveryAddress" => "1234, ABC Street",
+            ],
+            "callbackUrl" => "http://localhost:8000/payment_link_result",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("success", $response["status"]);
+        $this->assertEquals("https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312", $response["location"]);
+    }
+
+    public function testCreatePaymentLinkWithoutPaymentReferenceSucceeds()
+    {
+        $response = $this->paymentLinkService->createPaymentLink([
+            "tillNumber" => "4321",
+            "currency" => "KES",
+            "amount" => 2000.00,
+            "note" => "Note to customer",
+            "metadata" => [
+                "promotionDetails" => "End of Year Sale",
+                "deliveryAddress" => "1234, ABC Street",
+            ],
+            "callbackUrl" => "http://localhost:8000/payment_link_result",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("success", $response["status"]);
+        $this->assertEquals("https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312", $response["location"]);
+    }
+
+    public function testCreatePaymentLinkWithoutNoteSucceeds()
+    {
+        $response = $this->paymentLinkService->createPaymentLink([
+            "tillNumber" => "4321",
+            "currency" => "KES",
+            "amount" => 2000.00,
+            "paymentReference" => "INV29390943",
+            "metadata" => [
+                "promotionDetails" => "End of Year Sale",
+                "deliveryAddress" => "1234, ABC Street",
+            ],
+            "callbackUrl" => "http://localhost:8000/payment_link_result",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("success", $response["status"]);
+        $this->assertEquals("https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312", $response["location"]);
+    }
+
+    public function testCreatePaymentLinkWithoutMetadataSucceeds()
+    {
+        $response = $this->paymentLinkService->createPaymentLink([
+            "tillNumber" => "4321",
+            "currency" => "KES",
+            "amount" => 2000.00,
+            "paymentReference" => "INV29390943",
+            "note" => "Note to customer",
+            "callbackUrl" => "http://localhost:8000/payment_link_result",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("success", $response["status"]);
+        $this->assertEquals("https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312", $response["location"]);
+    }
+
+    public function testCreatePaymentLinkWithoutTillNumberFails()
+    {
+        $response = $this->paymentLinkService->createPaymentLink([
+            "currency" => "KES",
+            "amount" => 2000.00,
+            "paymentReference" => "INV29390943",
+            "note" => "Note to customer",
+            "metadata" => [
+                "promotionDetails" => "End of Year Sale",
+                "deliveryAddress" => "1234, ABC Street",
+            ],
+            "callbackUrl" => "http://localhost:8000/payment_link_result",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the tillNumber", $response["data"]);
+    }
+
+    public function testCreatePaymentLinkWithoutCurrencyFails()
+    {
+        $response = $this->paymentLinkService->createPaymentLink([
+            "tillNumber" => "4321",
+            "amount" => 2000.00,
+            "paymentReference" => "INV29390943",
+            "note" => "Note to customer",
+            "metadata" => [
+                "promotionDetails" => "End of Year Sale",
+                "deliveryAddress" => "1234, ABC Street",
+            ],
+            "callbackUrl" => "http://localhost:8000/payment_link_result",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the currency", $response["data"]);
+    }
+
+    public function testCreatePaymentLinkWithoutAmountFails()
+    {
+        $response = $this->paymentLinkService->createPaymentLink([
+            "tillNumber" => "4321",
+            "currency" => "KES",
+            "paymentReference" => "INV29390943",
+            "note" => "Note to customer",
+            "metadata" => [
+                "promotionDetails" => "End of Year Sale",
+                "deliveryAddress" => "1234, ABC Street",
+            ],
+            "callbackUrl" => "http://localhost:8000/payment_link_result",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the amount", $response["data"]);
+    }
+
+    public function testCreatePaymentLinkWithoutCallbackUrlFails()
+    {
+        $response = $this->paymentLinkService->createPaymentLink([
+            "tillNumber" => "4321",
+            "currency" => "KES",
+            "amount" => 2000.00,
+            "paymentReference" => "INV29390943",
+            "note" => "Note to customer",
+            "metadata" => [
+                "promotionDetails" => "End of Year Sale",
+                "deliveryAddress" => "1234, ABC Street",
+            ],
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the callbackUrl", $response["data"]);
+    }
+
+    public function testCreatePaymentLinkWithoutAccessTokenFails()
+    {
+        $response = $this->paymentLinkService->createPaymentLink([
+            "tillNumber" => "4321",
+            "currency" => "KES",
+            "amount" => 2000.00,
+            "paymentReference" => "INV29390943",
+            "note" => "Note to customer",
+            "metadata" => [
+                "promotionDetails" => "End of Year Sale",
+                "deliveryAddress" => "1234, ABC Street",
+            ],
+            "callbackUrl" => "http://localhost:8000/payment_link_result",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the accessToken", $response["data"]);
+    }
+
+    public function testCreatePaymentLinkHandlesRequestExceptionsGracefully()
+    {
+        $this->setUpPaymentLinkRequestError();
+        $response = $this->paymentLinkService->createPaymentLink([
+            "tillNumber" => "0000",
+            "currency" => "KES",
+            "amount" => 2000.00,
+            "paymentReference" => "INV29390943",
+            "note" => "Note to customer",
+            "metadata" => [
+                "promotionDetails" => "End of Year Sale",
+                "deliveryAddress" => "1234, ABC Street",
+            ],
+            "callbackUrl" => "http://localhost:8000/payment_link_result",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("400", $response["data"]["errorCode"]);
+        $this->assertEquals("Till number is invalid", $response["data"]["errorMessage"]);
+    }
+
+    // Cancel payment link
+    public function testCancelPaymentLinkSucceeds() {
+        $this->setUpCancelPaymentLink();
+        $response = $this->paymentLinkService->cancelPaymentLink([
+            "location" => "https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("success", $response["status"]);
+        $this->assertEquals("Payment link cancelled.", $response["message"]);
+    }
+
+    public function testCancelPaymentLinkWithoutLocationFails()
+    {
+        $this->setUpCancelPaymentLink();
+        $response = $this->paymentLinkService->cancelPaymentLink([
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the location", $response["data"]);
+    }
+
+    public function testCancelPaymentLinkWithoutAccessTokenFails()
+    {
+        $this->setUpCancelPaymentLink();
+        $response = $this->paymentLinkService->cancelPaymentLink([
+            "location" => "https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the accessToken", $response["data"]);
+    }
+
+    public function testCancelPaymentLinkHandlesRequestExceptionsGracefully()
+    {
+        $this->setUpPaymentLinkRequestError();
+        $response = $this->paymentLinkService->cancelPaymentLink([
+            "location" => "https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("400", $response["data"]["errorCode"]);
+        $this->assertEquals("Till number is invalid", $response["data"]["errorMessage"]);
+    }
+
+    // Get payment link status
+    public function testGetPaymentLinkStatusSucceeds()
+    {
+        $this->setUpGetPaymentLinkStatus();
+        $result = json_decode(file_get_contents(__DIR__."/Mocks/paymentLinks/paymentLinkStatus.json"), true)["data"];
+        $response = $this->paymentLinkService->getStatus([
+            "location" => "https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312",
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $formattedResult = [
+            "id" => $result["id"],
+            "type" => $result["type"],
+            "status" => $result["attributes"]["status"],
+            "currency" => $result["attributes"]["currency"],
+            "amount" => $result["attributes"]["amount"],
+            "tillName" => $result["attributes"]["till_name"],
+            "tillNumber" => $result["attributes"]["till_number"],
+            "paymentReference" => $result["attributes"]["payment_reference"],
+            "note" => $result["attributes"]["note"],
+            "createdAt" => $result["attributes"]["created_at"],
+            "paymentLink" => K2Utils::deepCamelizeKeys($result["attributes"]["payment_link"]),
+            "errors" => $result["attributes"]["errors"],
+            "metadata" => $result["attributes"]["metadata"],
+            "callbackUrl" => $result["attributes"]["_links"]["callback_url"],
+            "linkSelf" => $result["attributes"]["_links"]["self"],
+        ];
+
+        $this->assertEquals("success", $response["status"]);
+        $this->assertEquals($formattedResult, $response["data"]);
+    }
+
+    public function testGetPaymentLinkStatusWithoutLocationFails()
+    {
+        $this->setUpGetPaymentLinkStatus();
+        $response = $this->paymentLinkService->getStatus([
+            "accessToken" => "myRand0mAcc3ssT0k3n",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the location", $response["data"]);
+    }
+
+    public function testGetPaymentLinkStatusWithoutAccessTokenFails()
+    {
+        $this->setUpGetPaymentLinkStatus();
+        $response = $this->paymentLinkService->getStatus([
+            "location" => "https://sandbox.kopokopo.com/api/v2/payment_links/d5963294-22bf-46f6-a13c-b6a9951b4312",
+        ]);
+
+        $this->assertEquals("error", $response["status"]);
+        $this->assertEquals("You have to provide the accessToken", $response["data"]);
+    }
+}


### PR DESCRIPTION
This PR adds functionality to create, cancel and view payment links
**Payment links on example app**
[Screencast from 2026-01-21 22-26-15.webm](https://github.com/user-attachments/assets/e7afe331-89e9-40e8-b919-cebeef6494a7)


**Payment link creation response**
<img width="716" height="90" alt="image" src="https://github.com/user-attachments/assets/5c9565f0-642b-41d1-8dcb-ca077c5d3650" />


**Payment link status**
<img width="854" height="403" alt="image" src="https://github.com/user-attachments/assets/315c363c-ecbd-4121-8987-6344d949e441" />


**Payment link error**
<img width="397" height="221" alt="image" src="https://github.com/user-attachments/assets/426b017a-b556-4744-a0f0-7d74616ad3c1" />

**Payment link cancellation**
<img width="327" height="90" alt="image" src="https://github.com/user-attachments/assets/f6ddf34c-b43d-4a72-bf04-b14a9d56e4a3" />



**Payment link service test cases**
<img width="765" height="539" alt="image" src="https://github.com/user-attachments/assets/7708be6e-7058-476a-b020-0548edbfaf24" />


**All test cases**
<img width="813" height="221" alt="image" src="https://github.com/user-attachments/assets/c6a58ab7-8ac8-482c-a29f-049c972eccbf" />
