### PR TITLE
KK-12082: Add daraja payload flag to webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ $response = $webhooks->subscribe([
     'url' => 'http://localhost:8000/webhook',
     'scope' => 'till',
     'scopeReference' => '000000',
-    'accessToken' => 'my_access_token'
+    'accessToken' => 'my_access_token',
+    'enableDarajaPayload' => 'false'
 ]);
 
 print_r($response);

--- a/example/index.php
+++ b/example/index.php
@@ -3,6 +3,7 @@
 require 'vendor/autoload.php';
 
 use Kopokopo\SDK\K2;
+use Kopokopo\SDK\Data\DataHandler;
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->safeLoad();
 
@@ -162,15 +163,7 @@ $router->map('POST', '/webhook/subscribe', function () {
 
     $tokens = $K2->TokenService();
     $response = $tokens->getToken();
-
-    // echo json_encode($response);
-    // echo json_encode($response['data']);
-    // echo json_encode($response['data']['accessToken']);
-
-    $access_token = $response['data']['accessToken'];
-
-    // echo $access_token;
-
+    $accessToken = $response['data']['accessToken'];
     $webhooks = $K2->Webhooks();
 
     $options = array(
@@ -178,11 +171,12 @@ $router->map('POST', '/webhook/subscribe', function () {
         'url' => $_POST['url'],
         'scope' => $_POST['scope'],
         'scopeReference' => $_POST['scope_ref'],
-        'accessToken' => $access_token,
+        'accessToken' => $accessToken,
+        'enableDarajaPayload' => isset($_POST['enableDarajaPayload']),
     );
     $response = $webhooks->subscribe($options);
 
-    echo json_encode($response);
+    echo "<pre>".json_encode($response, JSON_ENCODING_FLAGS)."</pre>";
 });
 
 $router->map('POST', '/stk', function () {
@@ -438,7 +432,8 @@ $router->map('GET', '/webhook/resource', function () {
     $file = __DIR__ . '/last_response.json';
 
     if (file_exists($file)) {
-        echo file_get_contents($file);
+        $dataHandler = new DataHandler(json_decode(file_get_contents($file), true));
+        echo "<pre>".json_encode($dataHandler->dataHandlerSort(), JSON_ENCODING_FLAGS)."</pre>";
     } else {
         echo json_encode(['message' => 'No response yet.']);
     }

--- a/example/last_response.json
+++ b/example/last_response.json
@@ -1,1 +1,28 @@
-{"status":"success","data":{"id":"9a1ac4d5-76dc-4569-a03c-532938763ffa","type":"settlement_transfer","createdAt":"2025-09-12T04:27:51.607+03:00","status":"Transferred","amount":"236","currency":"KES","transferBatches":[{"status":"Transferred","amount":"236","disbursements":[{"amount":"236","status":"Transferred","origination_time":"2025-09-12T04:27:51.607+03:00","transaction_reference":1757640471,"destination_type":"merchant_bank_account","destination_reference":"cc0e5289-f964-4fc0-8e81-ab48fdb3d3d9"}]}],"linkSelf":"https:\/\/sandbox.kopokopo.com\/api\/v1\/settlement_transfers\/9a1ac4d5-76dc-4569-a03c-532938763ffa","callbackUrl":"https:\/\/8532fa4c3a42.ngrok-free.app\/webhook"}}
+{
+  "topic": "buygoods_transaction_received",
+  "id": "72852c5a-7df0-4b72-b102-6afc07e87eed",
+  "created_at": "2026-04-01T17:28:54+03:00",
+  "event": {
+    "type": "Buygoods Transaction",
+    "resource": {
+      "id": "5f0f7d47-963b-4497-a712-3de60b6c9013",
+      "amount": "1000.0",
+      "status": "Received",
+      "system": "Lipa Na M-PESA",
+      "currency": "KES",
+      "reference": "APR4302026",
+      "till_number": "4321",
+      "account_number": "N/A",
+      "origination_time": "2026-04-03T17:28:54+03:00",
+      "sender_last_name": "",
+      "sender_first_name": "John",
+      "sender_middle_name": "",
+      "hashed_sender_phone": "52f759371801ab5f16266f12d5e1af9b08b96424e36266f40e4a6cb48d34d5f3",
+      "sender_phone_number": "+254900111222"
+    }
+  },
+  "_links": {
+    "self": "https://api.kopokopo.com/webhook_events/72852c5a-7df0-4b72-b102-6afc07e87eed",
+    "resource": "https://api.kopokopo.com/financial_transaction/5f0f7d47-963b-4497-a712-3de60b6c9013"
+  }
+}

--- a/example/views/partials/nav.php
+++ b/example/views/partials/nav.php
@@ -15,6 +15,7 @@
                 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                     <a class="dropdown-item" href="/webhook/subscribe">Webhook Subscribe</a>
                     <a class="dropdown-item" href="/webhook/resource">Buy Goods Received Resource</a>
+                    <a class="dropdown-item" href="/status">Query Subscription Status</a>
                 </div>
             </li>
             <li class="nav-item dropdown">

--- a/example/views/subscribe.php
+++ b/example/views/subscribe.php
@@ -6,7 +6,7 @@
         <div class="form-group row">
             <label class="col-sm-3 col-form-label" (for="eventType")> Event Type </label>
             <div class="col-sm-7">
-                <select name = "eventType">
+                <select class="form-control" name = "eventType">
                     <option value="buygoods_transaction_received"> Buygoods Transaction Received </option>
                     <option value="b2b_transaction_received"> B2b Transaction Received </option>
                     <option value="m2m_transaction_received"> M2m Transaction Received </option>
@@ -19,7 +19,7 @@
         <div class="form-group row">
             <label class="col-sm-3 col-form-label" (for="scope")> Scope </label>
             <div class="col-sm-7">
-                <select name = "scope">
+                <select class="form-control" name = "scope">
                     <option value="company"> Company </option>
                     <option value="till"> Till </option>
                 </select>
@@ -35,6 +35,15 @@
             </div>
         </div>
         <div class="form-group row">
+            <label class="col-sm-3 col-form-label" (for="enableDarajaPayload")>Enable darja payload</label>
+            <div class="col-sm-7">
+                <input class="form-control" name="enableDarajaPayload" type="checkbox" style="width: 1.5rem; height: 1.5rem" switch/>
+                <div class="small form-text text-muted">
+                    Enable daraja payload
+                </div>
+            </div>
+        </div>
+        <div class="form-group row">
             <label class="col-sm-3 col-form-label" (for="url")> URL </label>
             <div class="col-sm-7">
                 <input class="form-control" name="url"  type='text' placeholder='Enter URL' required/>
@@ -44,11 +53,34 @@
             </div>
         </div>
         <br/>
-        <div class="form-group.row">
+        <div class="form-group row">
             <div class="col-sm-7">
                 <button class="btn btn-success"(type='submit')> Subscribe
             </div>
         </div>
     </form>
-</div> 
+</div>
+
+<script>
+    $("document").ready(() => {
+        const eventType = $("select[name='eventType']");
+        const enableDarajaPayload = $("input[name='enableDarajaPayload']");
+        const darajaEventTypes = ["buygoods_transaction_received", "b2b_transaction_received"]
+
+        toggleEnableDarajaPayloadCheckbox(eventType.val());
+
+        eventType.on("change", function() {
+            toggleEnableDarajaPayloadCheckbox($(this).val());
+        });
+
+        function toggleEnableDarajaPayloadCheckbox(eventType) {
+            if (darajaEventTypes.includes(eventType)) {
+                enableDarajaPayload.prop("disabled", false);
+            } else {
+                enableDarajaPayload.prop("disabled", true);
+                enableDarajaPayload.prop("checked", false);
+            }
+        }
+    })
+</script>
 

--- a/src/data/WebhookSubscriptionData.php
+++ b/src/data/WebhookSubscriptionData.php
@@ -15,6 +15,7 @@ class WebhookSubscriptionData
         $data['status'] = $result['attributes']['status'];
         $data['scope'] = $result['attributes']['scope'];
         $data['scopeReference'] = $result['attributes']['scope_reference'];
+        $data['darajaEnabled'] = $result['attributes']['daraja_enabled'];
        
         return $data;
     }

--- a/src/requests/WebhookSubscribeRequest.php
+++ b/src/requests/WebhookSubscribeRequest.php
@@ -4,22 +4,22 @@ namespace Kopokopo\SDK\Requests;
 
 class WebhookSubscribeRequest extends BaseRequest
 {
-    public function getEventType()
+    public function getEventType(): string
     {
         return $this->getRequestData('eventType');
     }
 
-    public function getUrl()
+    public function getUrl(): string
     {
         return $this->getRequestData('url');
     }
 
-    public function getScope()
+    public function getScope(): string
     {
         return $this->getRequestData('scope');
     }
 
-    public function getScopeRef()
+    public function getScopeRef(): ?string
     {
         if (!isset($this->data['scopeReference']) && strtolower($this->getScope()) == 'company' ) {
             return null;
@@ -28,13 +28,19 @@ class WebhookSubscribeRequest extends BaseRequest
         return $this->getRequestData('scopeReference');
     }
 
-    public function getWebhookSubscribeBody()
+    public function enableDarajaPayload(): ?bool
+    {
+        return $this->data["enableDarajaPayload"] ?? null;
+    }
+
+    public function getWebhookSubscribeBody(): array
     {
         return [
             'event_type' => $this->getEventType(),
             'url' => $this->getUrl(),
             'scope' => $this->getScope(),
-            'scope_reference' => $this->getScopeRef()
+            'scope_reference' => $this->getScopeRef(),
+            'enable_daraja_payload' => $this->enableDarajaPayload()
         ];
     }
 }

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -62,6 +62,21 @@ class WebhookTest extends TestCase
             'url' => 'http://localhost:8000/webhook',
             'accessToken' => 'myRand0mAcc3ssT0k3n',
             'scope' => 'Company',
+            'scopeReference' => null,
+            'enableDarajaPayload' => true,
+        ]);
+
+        $this->assertArrayHasKey('status', $response);
+        $this->assertEquals('success', $response['status']);
+    }
+
+    public function testWebhookSubscribeWithoutEnableDarajaPayloadSucceeds()
+    {
+        $response = $this->subscribeClient->subscribe([
+            'eventType' => 'buygoods_transaction_received',
+            'url' => 'http://localhost:8000/webhook',
+            'accessToken' => 'myRand0mAcc3ssT0k3n',
+            'scope' => 'Company',
             'scopeReference' => null
         ]);
 
@@ -75,7 +90,8 @@ class WebhookTest extends TestCase
             'url' => 'http://localhost:8000/webhook',
             'accessToken' => 'myRand0mAcc3ssT0k3n',
             'scope' => 'company',
-            'scopeReference' => '1'
+            'scopeReference' => '1',
+            'enableDarajaPayload' => true,
         ]);
 
         $this->assertArrayHasKey('data', $response);
@@ -89,6 +105,7 @@ class WebhookTest extends TestCase
             'url' => 'http://localhost:8000/webhook',
             'accessToken' => 'myRand0mAcc3ssT0k3n',
             'scopeReference' => '1',
+            'enableDarajaPayload' => true,
         ]);
 
         $this->assertArrayHasKey('data', $response);
@@ -102,6 +119,7 @@ class WebhookTest extends TestCase
             'url' => 'http://localhost:8000/webhook',
             'accessToken' => 'myRand0mAcc3ssT0k3n',
             'scope' => 'till',
+            'enableDarajaPayload' => true,
         ]);
 
         $this->assertArrayHasKey('data', $response);
@@ -114,7 +132,8 @@ class WebhookTest extends TestCase
             'eventType' => 'buygoods_transaction_received',
             'accessToken' => 'myRand0mAcc3ssT0k3n',
             'scope' => 'company',
-            'scopeReference' => '1'
+            'scopeReference' => '1',
+            'enableDarajaPayload' => true,
         ]);
 
         $this->assertArrayHasKey('data', $response);
@@ -127,16 +146,13 @@ class WebhookTest extends TestCase
             'eventType' => 'buygoods_transaction_received',
             'url' => 'http://localhost:8000/webhook',
             'scope' => 'company',
-            'scopeReference' => '1'
+            'scopeReference' => '1',
+            'enableDarajaPayload' => true,
         ]);
 
         $this->assertArrayHasKey('data', $response);
         $this->assertEquals('You have to provide the accessToken', $response['data']);
     }
-
-    /*
-    *   Webhook handler tests
-    */
 
     /**
      * @expectedException \ArgumentCountError


### PR DESCRIPTION
This PR adds daraja payload param to webhook susbcription request, enabling integrators to enable daraja payload for buygoods and b2b transaction received event subscriptions. 

[Screencast from 2026-04-03 14-06-16.webm](https://github.com/user-attachments/assets/fa7b4f87-f649-4e5b-a0f7-deaf6fee088e)


**Daraja enabled susbscription**
<img width="1432" height="238" alt="image" src="https://github.com/user-attachments/assets/614d9ede-1996-46f6-bb95-634fbb5c8a2c" />

**Subscription not enabled for daraja payload**
<img width="1432" height="238" alt="image" src="https://github.com/user-attachments/assets/accdfa92-368f-4d62-8c77-ad011e8a0eae" />

**Subscription that does not support daraja payload**
<img width="1432" height="238" alt="image" src="https://github.com/user-attachments/assets/99b7d157-7ded-4f47-a0b2-ec18a0ff8987" />



## Tests
**Webhook service tests**
<img width="649" height="352" alt="image" src="https://github.com/user-attachments/assets/c7d2cb3d-fd55-47c2-a404-fe41a015c29d" />

**All tests**
<img width="868" height="228" alt="image" src="https://github.com/user-attachments/assets/e419bcb9-4907-4277-9177-65ab9e72dc5e" />

